### PR TITLE
Updated lazy_static 0.1 → 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "simple_signal"
 libc = "0.2"
 
 [dependencies.lazy_static]
-version = "0.1"
+version = "0.2"
 optional = true
 
 [features]


### PR DESCRIPTION
Nothing functional changed here, this is just to reduce having multiple (older) versions of crates to be in dependencies.

Should only be a minor version bump.