### PR TITLE
Allow `FnMut` handler functions and placate clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,4 @@ name = "simple_signal"
 
 [dependencies]
 libc = "0.2"
-
-[dependencies.lazy_static]
-version = "1.0"
-optional = true
-
-[features]
-default = ["stable"]
-nightly = []
-stable = ["lazy_static"]
+lazy_static = "1.4"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,3 @@ fn main() {
 
 #### Try the example yourself
 `cargo run --example readme_example`
-
-## Building
-If you're using a nightly compiler, I suggest building with `cargo build --features nightly` to avoid the dependency on *lazy_static*. On stable and beta compilers, just run `cargo build`.


### PR DESCRIPTION
Started as "the handler function can be a `FnMut` without any other changes"... went down a bit of a rabbit hole while I was there:

* Fixed up various clippy warnings
* Removed the `nightly` feature since `static_mutex`/`static_condvar` has disappeared in nightly (you might consider keeping the feature name as a no-op so this isn't a breaking change?)
* Replaced some deprecated code (`AtomicUint::compare_and_swap`)

I also considered but managed to stop myself from:

* Running `cargo fmt` - but it broken up a lot of single lines into three lines in an annoying way, could still be worth doing
* Adding `clippy`/`fmt` to the travis-ci script - couldn't add `fmt` due to previous bullet and didn't add `clippy` because it's annoying to add (do you enable `-Dwarnings`?  do you `allow_failure`?  what if clippy adds a new lint?)